### PR TITLE
[k8s_gcp] Option to force Kubernetes use host's FQDN as node name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['kube-hops']['dns_ip']                            = "10.96.0.10"
 default['kube-hops']['fallback_dns']                      = ""
 default['kube-hops']['flannel']['iface-regex']            = ""
 default['kube-hops']['cluster_domain']                    = "cluster.local"
+default['kube-hops']['hostname_override']                 = "true"
 
 # Apiserver
 default['kube-hops']['apiserver']['port']                 = "6443"

--- a/metadata.rb
+++ b/metadata.rb
@@ -55,6 +55,10 @@ attribute "kube-hops/cluster_domain",
           :description =>  "Kubernetes cluster domain. Default: cluster.local",
           :type => 'string'
 
+attribute "kube-hops/hostname_override",
+          :description =>  "Flag to force Kubernetes use FQDN of host as node name. Default: true",
+          :type => 'string'
+
 attribute "kube-hops/apiserver/port",
           :description =>  "Port on which the apiserver listens for requests",
           :type => 'string'

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -130,6 +130,11 @@ kube_hops_conf "admin" do
   not_if      { ::File.exist?("#{node['kube-hops']['conf_dir']}/admin.conf") }
 end
 
+if node['kube-hops']['hostname_override'].casecmp?("true")
+  node_name = node['fqdn']
+else
+  node_name = ""
+end
 # Template kubeadm configuration file
 template "#{node['kube-hops']['conf_dir']}/kubeadm.conf" do
   source "kubeadm-config.erb"
@@ -137,7 +142,8 @@ template "#{node['kube-hops']['conf_dir']}/kubeadm.conf" do
   group "root"
   mode "700"
   variables ({
-    'api_address': private_ip
+    'api_address': private_ip,
+    'node_name': node_name
   })
 end
 

--- a/templates/default/kubeadm-config.erb
+++ b/templates/default/kubeadm-config.erb
@@ -15,6 +15,10 @@ etcd:
     image: ""
 imageRepository: <%= node['kube-hops']['image_repo'] %>
 kind: MasterConfiguration
+<% if node['kube-hops']['hostname_override'].casecmp?("true") -%>
+nodeRegistration:
+  name: <%= @node_name %>
+<% end -%>
 kubeProxy:
   config:
     bindAddress: 0.0.0.0
@@ -34,7 +38,7 @@ kubeProxy:
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
     healthzBindAddress: 0.0.0.0:10256
-    hostnameOverride: ""
+    hostnameOverride: "<%= @node_name %>"
     iptables:
       masqueradeAll: false
       masqueradeBit: 14

--- a/templates/default/kubeadm-flags.erb
+++ b/templates/default/kubeadm-flags.erb
@@ -1,1 +1,1 @@
-KUBELET_KUBEADM_ARGS=--cgroup-driver=<%= node['kube-hops']['cgroup-driver'] %> --cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --network-plugin=cni <%= @centos_conf %>
+KUBELET_KUBEADM_ARGS=--cgroup-driver=<%= node['kube-hops']['cgroup-driver'] %> <% if node['kube-hops']['hostname_override'].casecmp?("true") -%>--hostname-override=<%= node['fqdn'] %><% end -%> --cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --network-plugin=cni <%= @centos_conf %>


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1739