### PR TITLE
[HOPSWORKS-2553] Change kfserving-controller pull policy to IfNotPresent

### DIFF
--- a/templates/default/kfserving.yml.erb
+++ b/templates/default/kfserving.yml.erb
@@ -16232,7 +16232,7 @@ spec:
         - name: SECRET_NAME
           value: kfserving-webhook-server-cert
         image: gcr.io/kfserving/kfserving-controller:v0.5.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         ports:
         - containerPort: 9443


### PR DESCRIPTION
Always always tries to pull the image and fails if it can't. This breaks
in airgapped deployments